### PR TITLE
feat: Report correct errors for missing `use client` in global-errors.ts (#69583)

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -880,9 +880,16 @@ export default abstract class Server<
             'http.method': method,
             'http.target': req.url,
           },
+          manualSpanEnd: true,
         },
         async (span) =>
           this.handleRequestImpl(req, res, parsedUrl).finally(() => {
+            res.onClose(() => {
+              if (span) {
+                span.end()
+              }
+            })
+
             if (!span) return
 
             const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false


### PR DESCRIPTION
### What?

Fixes a bug where telemetry spans for Pages Router requests are way too short. 

### Why?

The `handleRequestImpl` function is wrapped with `tracer.trace()` to trace the duration of Next.js handling a request. The `tracer.trace()` function immediately starts a span and ends it when the return value of the passed callback resolves.

In the pages router `handleRequestImpl` more or less immediately resolves, even though the request is still being processed. The started span is immediately ended, not waiting for `res.end()`, which should be the actual end timestamp of the span.

### How?

I adjusted the `tracer.trace()` function to take an optional `manualSpanEnd` option, which will make the `tracer.trace()` function not end the span when the promise resolves. Additionally, we now manually end the request span with the `onClose` hook.

Relates to https://github.com/vercel/next.js/discussions/64723
